### PR TITLE
feat: adding email and time fields to API calls and student objects

### DIFF
--- a/back/data/all-attendance.csv
+++ b/back/data/all-attendance.csv
@@ -3,3 +3,4 @@ BeginTime, EndTime, AllDBPs, AllHRQs, Pairs, UnassignedDBPs, UnseenHRQs
 
 12-01-2023-12:48, 12-01-2023-12:50, 1: 2; 2: 2, a; b; c; d, Help Requester: a, Debugging Partner: 1; Help Requester: b, Debugging Partner: 2; Help Requester: c, Debugging Partner: 2; Help Requester: d, Debugging Partner: 1, , 
 12-01-2023-12-53, 12-01-2023-12-54, 1: 1; 2: 1; 3: 0, a; b, Help Requester: a, Debugging Partner: 1; Help Requester: b, Debugging Partner: 2, 3, 
+12-03-2023-06-03, 12-03-2023-06-04, DPone: 1, HRone, , , HRone

--- a/back/data/sessions/debugging-partner-attendance-12-03-2023-06-03.csv
+++ b/back/data/sessions/debugging-partner-attendance-12-03-2023-06-03.csv
@@ -1,0 +1,2 @@
+DebuggingPartnerName, DebuggingPartnerEmail, HelpRequestersSeen
+DPone, DPone@gmail.com, 1

--- a/back/data/sessions/help-requester-attendance-12-03-2023-06-03.csv
+++ b/back/data/sessions/help-requester-attendance-12-03-2023-06-03.csv
@@ -1,0 +1,2 @@
+HelpRequesterName, HelpRequesterEmail, AssignedDebuggingPartnerName
+HRone, , HRone@gmail.comnull

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/debuggingPartner/DebuggingPartner.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/debuggingPartner/DebuggingPartner.java
@@ -12,17 +12,28 @@ import edu.brown.cs32.livecode.dispatcher.utils.Utils;
  */
 public class DebuggingPartner implements Runnable {
   private final String name;
+  private final String email;
+  private final String joinedTime;
+  private String pairedAtTime;
   private int studentsHelped = 0;
   private HelpRequester helping = null;
   private boolean flagged = false;
 
-  public DebuggingPartner(String name) {
+  public DebuggingPartner(String name, String email) {
     this.name = name;
+    this.email = email;
+    this.joinedTime = Utils.simpleTime();
   }
 
   public String getName() {
     return name;
   }
+
+  public String getEmail() { return email; }
+
+  public String getJoinedTime() { return joinedTime; }
+
+  public String getPairedAtTime() { return pairedAtTime; }
 
   public void incrementStudentsHelper() {
     this.studentsHelped += 1;
@@ -46,6 +57,7 @@ public class DebuggingPartner implements Runnable {
 
   public void seeStudent(HelpRequester helpRequester) throws Exception {
     if (this.helping != null) throw new Exception();
+    this.pairedAtTime = Utils.simpleTime();
     this.helping = helpRequester;
 
     // *** Only uncomment one of these at a time ***

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/debuggingPartner/DebuggingPartnerQueue.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/debuggingPartner/DebuggingPartnerQueue.java
@@ -24,11 +24,11 @@ public class DebuggingPartnerQueue {
     debuggingPartnerList.add(newDebuggingPartner);
   }
 
-  public boolean removeDebuggingPartner(String name) {
+  public boolean removeDebuggingPartner(String name, String email) {
     boolean foundDebuggingPartner = false;
     List<DebuggingPartner> newDebuggingPartners = new ArrayList<>();
     for (DebuggingPartner debuggingPartner : debuggingPartnerList) {
-      if (!debuggingPartner.getName().equals(name)) {
+      if (!debuggingPartner.getName().equals(name) || !debuggingPartner.getEmail().equals(email)) {
         newDebuggingPartners.add(debuggingPartner);
       } else {
         foundDebuggingPartner = true;
@@ -46,12 +46,13 @@ public class DebuggingPartnerQueue {
     return allDebuggingPartners;
   }
 
-  public boolean removeAndFlagDebuggingPartner(String name) {
+  public boolean removeAndFlagDebuggingPartner(String name, String email) {
     boolean removed = false;
     DebuggingPartner toRemove = null;
     for (DebuggingPartner debuggingPartner : debuggingPartnerList) {
       String thisName = debuggingPartner.getName();
-      if (name.equals(thisName)) {
+      String thisEmail = debuggingPartner.getEmail();
+      if (name.equals(thisName) && email.equals(thisEmail)) {
         toRemove = debuggingPartner;
         removed = true;
         toRemove.setFlagged();

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/AddDebuggingPartnerHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/AddDebuggingPartnerHandler.java
@@ -24,13 +24,18 @@ public class AddDebuggingPartnerHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String name = request.queryParams("debuggingPartner");
+    String name = request.queryParams("name");
+    String email = request.queryParams("email");
     if (name == null) {
       return new FailureResponse(
-              "error_bad_request", "Missing required parameter: debuggingPartner")
+              "error_bad_request", "Missing required parameter: name")
+          .serialize();
+    } else if (email == null) {
+      return new FailureResponse(
+          "error_bad_request", "Missing required parameter: email")
           .serialize();
     }
-    debuggingPartnerQueue.addDebuggingPartner(new DebuggingPartner(name));
+    debuggingPartnerQueue.addDebuggingPartner(new DebuggingPartner(name, email));
     return new SuccessResponse("success", "Debugging Partner " + name + " was added to the queue.")
         .serialize();
   }

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/AddHelpRequesterHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/AddHelpRequesterHandler.java
@@ -22,12 +22,16 @@ public class AddHelpRequesterHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String name = request.queryParams("helpRequester");
+    String name = request.queryParams("name");
+    String email = request.queryParams("email");
     if (name == null) {
-      return new FailureResponse("error_bad_request", "Missing required parameter: helpRequester")
+      return new FailureResponse("error_bad_request", "Missing required parameter: name")
+          .serialize();
+    } else if (email == null) {
+      return new FailureResponse("error_bad_request", "Missing required parameter: email")
           .serialize();
     }
-    helpRequesterQueue.addNeedsHelp(new HelpRequester(name));
+    helpRequesterQueue.addNeedsHelp(new HelpRequester(name, email));
     return new SuccessResponse("success", "Help Requester " + name + " was added to the queue.")
         .serialize();
   }

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/DebuggingPartnerDoneHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/DebuggingPartnerDoneHandler.java
@@ -23,13 +23,18 @@ public class DebuggingPartnerDoneHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String name = request.queryParams("debuggingPartner");
+    String name = request.queryParams("name");
+    String email = request.queryParams("email");
     if (name == null) {
       return new FailureResponse(
-              "error_bad_request", "Missing required parameter: debuggingPartner")
+              "error_bad_request", "Missing required parameter: name")
+          .serialize();
+    } else if (email == null) {
+      return new FailureResponse(
+          "error_bad_request", "Missing required parameter: email")
           .serialize();
     }
-    boolean setSuccess = debuggingPartnerQueue.removeDebuggingPartner(name);
+    boolean setSuccess = debuggingPartnerQueue.removeDebuggingPartner(name, email);
     if (setSuccess) {
       return new SuccessResponse("success", "Debugging Partner " + name + " has left!").serialize();
     } else {

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/EscalateHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/EscalateHandler.java
@@ -23,19 +23,24 @@ public class EscalateHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String name = request.queryParams("helpRequester");
-    if (name == null) {
-      return new FailureResponse("error_bad_request", "Missing required parameter: helpRequester")
+    String helpRequesterName = request.queryParams("helpRequesterName");
+    String helpRequesterEmail = request.queryParams("helpRequesterEmail");
+    if (helpRequesterName == null) {
+      return new FailureResponse("error_bad_request", "Missing required parameter: helpRequesterName")
+          .serialize();
+    } else if (helpRequesterEmail == null) {
+      return new FailureResponse("error_bad_request", "Missing required parameter: helpRequesterEmail")
           .serialize();
     }
-    boolean setSuccess = helpRequesterQueue.setEscalated(name);
+    boolean setSuccess = helpRequesterQueue.setEscalated(helpRequesterName, helpRequesterEmail);
     if (setSuccess) {
       return new SuccessResponse(
-          "success", "Help Requester " + name + " has been escalated!")
+          "success", "Help Requester " + helpRequesterName + " has been escalated!")
           .serialize();
     } else {
       return new FailureResponse(
-          "error_bad_request", "Help Requester " + name + " not found in queue.")
+          "error_bad_request", "Help Requester " + helpRequesterName +
+          " with email " + helpRequesterEmail + " not found in queue.")
           .serialize();
     }
   }

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/FlagAndRematchHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/FlagAndRematchHandler.java
@@ -28,22 +28,43 @@ public class FlagAndRematchHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String debuggingPartnerName = request.queryParams("debuggingPartner");
-    String helpRequesterName = request.queryParams("helpRequester");
-    if (debuggingPartnerName == null || helpRequesterName == null) {
+    String debuggingPartnerName = request.queryParams("debuggingPartnerName");
+    String debuggingPartnerEmail = request.queryParams("debuggingPartnerEmail");
+    String helpRequesterName = request.queryParams("helpRequesterName");
+    String helpRequesterEmail = request.queryParams("helpRequesterEmail");
+    if (debuggingPartnerName == null) {
       return new FailureResponse(
-          "error_bad_request", "Missing some required parameter: debuggingPartner or helpRequester")
+          "error_bad_request", "Missing some required parameter: debuggingPartnerName")
+          .serialize();
+    } else if (debuggingPartnerEmail == null) {
+      return new FailureResponse(
+          "error_bad_request", "Missing some required parameter: debuggingPartnerEmail")
+          .serialize();
+    } else if (helpRequesterName == null) {
+      return new FailureResponse(
+          "error_bad_request", "Missing some required parameter: helpRequesterName")
+          .serialize();
+    } else if (helpRequesterEmail == null) {
+      return new FailureResponse(
+          "error_bad_request", "Missing some required parameter: helpRequesterEmail")
           .serialize();
     }
-    boolean flagSuccess = debuggingPartnerQueue.removeAndFlagDebuggingPartner(debuggingPartnerName);
-    boolean rematchSuccess = helpRequesterQueue.moveBackToQueue(helpRequesterName);
+    boolean paired = helpRequesterQueue.checkPaired(debuggingPartnerName, helpRequesterName);
+    if (!paired) {
+      return new FailureResponse(
+          "error_bad_request", "Debugging Partner " + debuggingPartnerName + " with email " +
+          debuggingPartnerEmail + " is not paired with Help Requester " + helpRequesterName + " with email " + helpRequesterEmail)
+          .serialize();
+    }
+    boolean flagSuccess = debuggingPartnerQueue.removeAndFlagDebuggingPartner(debuggingPartnerName, debuggingPartnerEmail);
+    boolean rematchSuccess = helpRequesterQueue.moveBackToQueue(helpRequesterName, helpRequesterEmail);
     if (!flagSuccess) {
       return new FailureResponse(
-          "error_bad_request", "Debugging Partner " + debuggingPartnerName + " not found in queue.")
+          "error_bad_request", "Debugging Partner " + debuggingPartnerName + " with email " + debuggingPartnerEmail + " not found in queue.")
           .serialize();
     } else if(!rematchSuccess) {
       return new FailureResponse(
-          "error_bad_request", "Help Requester " + helpRequesterName + " not found in queue.")
+          "error_bad_request", "Help Requester " + helpRequesterName + " with email " + helpRequesterEmail +  "not found in queue.")
           .serialize();
     } else {
       return new SuccessResponse("success", "Debugging Partner " + debuggingPartnerName +

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/HelpRequesterDoneHandler.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/handlers/HelpRequesterDoneHandler.java
@@ -23,12 +23,16 @@ public class HelpRequesterDoneHandler implements Route {
     if (!sessionState.getRunning()) {
       return new FailureResponse("error_bad_request", "No session is running.").serialize();
     }
-    String name = request.queryParams("helpRequester");
+    String name = request.queryParams("name");
+    String email = request.queryParams("email");
     if (name == null) {
-      return new FailureResponse("error_bad_request", "Missing required parameter: helpRequester")
+      return new FailureResponse("error_bad_request", "Missing required parameter: name")
+          .serialize();
+    } else if (email == null) {
+      return new FailureResponse("error_bad_request", "Missing required parameter: email")
           .serialize();
     }
-    boolean setSuccess = helpRequesterQueue.setDoneDebugging(name);
+    boolean setSuccess = helpRequesterQueue.setDoneDebugging(name, email);
     if (setSuccess) {
       return new SuccessResponse(
               "success", "Help Requester " + name + " has been debugged and allowed to leave!")

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequester.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequester.java
@@ -1,23 +1,33 @@
 package edu.brown.cs32.livecode.dispatcher.helpRequester;
 
 import edu.brown.cs32.livecode.dispatcher.debuggingPartner.DebuggingPartner;
+import edu.brown.cs32.livecode.dispatcher.utils.Utils;
 
 public class HelpRequester {
   private final String name;
-  private boolean debugged;
-  private boolean escalated;
-  private DebuggingPartner debuggingPartner;
+  private final String email;
+  private final String joinedTime;
+  private String pairedAtTime;
+  private boolean debugged = false;
+  private boolean escalated = false;
+  private DebuggingPartner debuggingPartner = null;
 
-  public HelpRequester(String name) {
+  public HelpRequester(String name, String email) {
     this.name = name;
-    this.debugged = false;
-    this.escalated = false;
-    this.debuggingPartner = null;
+    this.email = email;
+    this.joinedTime = Utils.simpleTime();
   }
 
   public String getName() {
     return name;
   }
+
+  public String getEmail() {
+    return email;
+  }
+  public String getJoinedTime() { return joinedTime; }
+
+  public String getPairedAtTime() { return pairedAtTime; }
 
   public void setDebugged(boolean newDebugged) {
     this.debugged = newDebugged;
@@ -29,6 +39,7 @@ public class HelpRequester {
 
   public void setDebuggingPartner(DebuggingPartner debuggingPartnerHelper) {
     this.debuggingPartner = debuggingPartnerHelper;
+    this.pairedAtTime = Utils.simpleTime();
   }
 
   public DebuggingPartner getDebuggingPartner() {

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequesterQueue.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequesterQueue.java
@@ -1,5 +1,6 @@
 package edu.brown.cs32.livecode.dispatcher.helpRequester;
 
+import edu.brown.cs32.livecode.dispatcher.debuggingPartner.DebuggingPartner;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -54,12 +55,13 @@ public class HelpRequesterQueue {
     gettingHelp.add(helpRequester);
   }
 
-  public boolean setDoneDebugging(String name) {
+  public boolean setDoneDebugging(String name, String email) {
     boolean debugged = false;
     HelpRequester toRemove = null;
     for (HelpRequester helpRequester : gettingHelp) {
       String thisName = helpRequester.getName();
-      if (name.equals(thisName)) {
+      String thisEmail = helpRequester.getEmail();
+      if (name.equals(thisName) && email.equals(thisEmail)) {
         helpRequester.setDebugged(true);
         alreadyHelped.add(helpRequester);
         toRemove = helpRequester;
@@ -70,11 +72,12 @@ public class HelpRequesterQueue {
     return debugged;
   }
 
-  public boolean setEscalated(String name) {
+  public boolean setEscalated(String helpRequesterName, String helpRequesterEmail) {
     boolean escalated = false;
     for (HelpRequester helpRequester : gettingHelp) {
       String thisName = helpRequester.getName();
-      if (name.equals(thisName)) {
+      String thisEmail = helpRequester.getEmail();
+      if (helpRequesterName.equals(thisName) && helpRequesterEmail.equals(thisEmail)) {
         helpRequester.setEscalated();
         escalated = true;
       }
@@ -82,12 +85,29 @@ public class HelpRequesterQueue {
     return escalated;
   }
 
-  public boolean moveBackToQueue(String name) {
+  public boolean checkPaired(String debuggingPartnerName, String helpRequesterName) {
+    for (HelpRequester helpRequester : gettingHelp) {
+      String thisHelpRequesterName = helpRequester.getName();
+      if (thisHelpRequesterName.equals(helpRequesterName)) {
+        DebuggingPartner debuggingPartner = helpRequester.getDebuggingPartner();
+        if (debuggingPartner != null) {
+          String thisDebuggingPartnerName = debuggingPartner.getName();
+          if (thisDebuggingPartnerName.equals(debuggingPartnerName)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  public boolean moveBackToQueue(String name, String email) {
     boolean moved = false;
     HelpRequester toMove = null;
     for (HelpRequester helpRequester : gettingHelp) {
       String thisName = helpRequester.getName();
-      if (name.equals(thisName)) {
+      String thisEmail = helpRequester.getEmail();
+      if (name.equals(thisName) && email.equals(thisEmail)) {
         helpRequester.setDebuggingPartner(null);
         toMove = helpRequester;
         moved = true;

--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/sessionState/CsvWriter.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/sessionState/CsvWriter.java
@@ -77,19 +77,20 @@ public class CsvWriter {
           new FileWriter("data/sessions/debugging-partner-attendance-" + beginTime + ".csv", true);
       FileWriter hrWriter =
           new FileWriter("data/sessions/help-requester-attendance-" + beginTime + ".csv", true);
-      dpWriter.write("DebuggingPartnerName, HelpRequestersSeen\n");
-      hrWriter.write("HelpRequesterName, AssignedDebuggingPartnerName\n");
+      dpWriter.write("DebuggingPartnerName, DebuggingPartnerEmail, JoinedTime, LastPairedAtTime, HelpRequestersSeen\n");
+      hrWriter.write("HelpRequesterName, HelpRequesterEmail, JoinedTime, PairAtTime, AssignedDebuggingPartnerName\n");
 
       List<HelpRequester> allHelpRequesters = helpRequesterQueue.getAllHelpRequesters();
       List<DebuggingPartner> allDebuggingPartners =
           debuggingPartnerQueue.getAllDebuggingPartnerList();
       for (DebuggingPartner debuggingPartner : allDebuggingPartners) {
-        dpWriter.write(
-            debuggingPartner.getName() + ", " + debuggingPartner.getStudentsHelped() + "\n");
+        dpWriter.write(debuggingPartner.getName() + ", " + debuggingPartner.getEmail() + ", " + debuggingPartner.getJoinedTime()
+            + ", " + debuggingPartner.getPairedAtTime() + ", " + debuggingPartner.getStudentsHelped() + "\n");
       }
       dpWriter.close();
       for (HelpRequester helpRequester : allHelpRequesters) {
-        hrWriter.write(helpRequester.getName() + ", " + helpRequester.getDebuggingPartner() + "\n");
+        hrWriter.write(helpRequester.getName() + ", " + helpRequester.getEmail() + ", " + helpRequester.getJoinedTime()
+            + ", " + helpRequester.getPairedAtTime() + ", " + helpRequester.getDebuggingPartner() + "\n");
       }
       hrWriter.close();
     } catch (IOException e) {


### PR DESCRIPTION
I updated the API requests so that they now take emails in addition to names. I am also now storing joined time and paired time for help requesters and debugging partners, which you will also see when you do a specific getInfo request. See the new list of API requests on the ReadME!