### PR TITLE
fix: setting help requester's db to null if db is removed

### DIFF
--- a/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequesterQueue.java
+++ b/back/src/main/java/edu/brown/cs32/livecode/dispatcher/helpRequester/HelpRequesterQueue.java
@@ -198,6 +198,7 @@ public class HelpRequesterQueue {
       if (helper != null
           && (helper.getName().equals(debuggingPartnerName))
           && helper.getEmail().equals(debuggingPartnerEmail)) {
+        helpRequester.setDebuggingPartner(null);
         toMove = helpRequester;
       }
     }


### PR DESCRIPTION
If a debugging partner is removed by a TA and they have already been matched, now their help requester's debugging partner is set to null.